### PR TITLE
Revamp site design with iOS styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Welcome! We're here to help.
-We are Hack Back, an organization dedicated to helping individuals respond to and overcome cybersecurity crime for the betterment of society.
+We Hack Back, an organization dedicated to helping individuals respond to and overcome cybersecurity crime for the betterment of society.
 If you are a victim of cybersecurity crime and need immediate assistance, please reach out to us on Signal here:
 
 # How does it work?

--- a/css/style.css
+++ b/css/style.css
@@ -1,27 +1,27 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap");
+/* Base styles */
+* {
+  box-sizing: border-box;
+}
 
-    * {
-      box-sizing: border-box;
-    }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: #222;
+  line-height: 1.6;
+  background: linear-gradient(to bottom, #ffffff, #f2f3f5);
+}
 
-    body {
-      margin: 0;
-        font-family: "Poppins", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      color: #222;
-      line-height: 1.6;
-      background: linear-gradient(to bottom, #ffffff, #e7f0fa);
-    }
-
-    .navbar {
-      background: #004d7a;
-      color: #fff;
-      padding: 1em 2em;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      position: sticky;
-      top: 0;
-    }
+/* Navigation */
+.navbar {
+  background: #007aff;
+  color: #fff;
+  padding: 1em 2em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: sticky;
+  top: 0;
+}
 
     .logo {
       font-weight: 700;
@@ -36,28 +36,28 @@
       gap: 1em;
     }
 
-    .nav-links a {
-      color: #fff;
-      text-decoration: none;
-      font-weight: 700;
-    }
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  transition: opacity 0.2s ease;
+}
 
-    .nav-links a:hover {
-      text-decoration: underline;
-    }
+.nav-links a:hover {
+  opacity: 0.8;
+}
 
-    .hero {
-      background:
-        linear-gradient(rgba(0,0,0,0.5), rgba(0,0,0,0.5)),
-        url('https://source.unsplash.com/1600x900/?cybersecurity') center/cover no-repeat;
-      color: #fff;
-      text-align: center;
-      padding: 8em 1em;
-      min-height: 100vh;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
+/* Hero */
+.hero {
+  background: linear-gradient(135deg, #0a84ff, #66a6ff);
+  color: #fff;
+  text-align: center;
+  padding: 8em 1em;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
 
     .hero h1 {
       font-size: 3em;
@@ -72,50 +72,51 @@
       margin-right: auto;
     }
 
-    .cta {
-      background: #00a8e8;
-      color: #fff;
-      padding: 0.75em 1.5em;
-      border-radius: 4px;
-      text-decoration: none;
-      font-weight: 700;
-    }
+.cta {
+  background: #007aff;
+  color: #fff;
+  padding: 0.75em 1.5em;
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.3s ease;
+}
 
-    .cta:hover {
-      background: #ff7000;
-    }
+.cta:hover {
+  background: #0051d4;
+}
 
-    .info {
-      padding: 4em 1em;
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-around;
-      background: #fff;
-    }
+.info {
+  padding: 4em 1em;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  background: #fff;
+}
 
-    .info:nth-of-type(even) {
-      background: #f4f4f4;
-    }
+.info:nth-of-type(even) {
+  background: #f2f2f7;
+}
 
-    .card {
-      flex: 0 0 300px;
-      margin: 1em;
-      padding: 2em;
-      border-radius: 8px;
-      background: #fff;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-      text-align: center;
-    }
+.card {
+  flex: 0 0 300px;
+  margin: 1em;
+  padding: 2em;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  text-align: center;
+}
 
-    footer {
-      background: #004d7a;
-      color: #fff;
-      text-align: center;
-      padding: 1.5em;
-    }
+footer {
+  background: #007aff;
+  color: #fff;
+  text-align: center;
+  padding: 1.5em;
+}
 #testimonials {
   padding: 4em 1em;
-  background: #e9f1f7;
+  background: #f2f2f7;
 }
 
 .testimonial-grid {
@@ -129,7 +130,7 @@
 .testimonial-grid blockquote {
   background: #fff;
   padding: 1.5em;
-  border-radius: 8px;
+  border-radius: 12px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   font-style: italic;
 }

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cyber Help Services</title>
+  <title>We Hack Back</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <nav class="navbar">
-    <div class="logo">Cyber Help Services</div>
+    <div class="logo">We Hack Back</div>
     <ul class="nav-links">
       <li><a href="#services">Services</a></li>
       <li><a href="#contact">Contact</a></li>
@@ -66,7 +66,7 @@
   </section>
 
   <footer>
-    &copy; 2024 Cyber Help Services. All rights reserved.
+    &copy; 2024 We Hack Back. All rights reserved.
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename Cyber Help Services to **We Hack Back**
- switch to system fonts and add iOS-inspired color scheme
- update call-to-action buttons, cards, testimonials and footer
- adjust README branding

## Testing
- `npm test` *(fails: package.json not found)*
- `make test` *(fails: no rule for target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686db6a3e47883218347e6041677849f