### PR TITLE
Refresh landing page colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,17 +3,22 @@
   box-sizing: border-box;
 }
 
+:root {
+  --blue: #0051d4;
+  --orange: #ff8c00;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: #222;
   line-height: 1.6;
-  background: linear-gradient(to bottom, #ffffff, #f2f3f5);
+  background: linear-gradient(135deg, var(--blue), var(--orange));
 }
 
 /* Navigation */
 .navbar {
-  background: #007aff;
+  background: var(--blue);
   color: #fff;
   padding: 1em 2em;
   display: flex;
@@ -49,11 +54,11 @@ body {
 
 /* Hero */
 .hero {
-  background: linear-gradient(135deg, #0a84ff, #66a6ff);
+  background: linear-gradient(135deg, var(--blue), var(--orange));
   color: #fff;
   text-align: center;
-  padding: 8em 1em;
-  min-height: 100vh;
+  padding: 6em 1em;
+  min-height: 70vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -73,7 +78,7 @@ body {
     }
 
 .cta {
-  background: #007aff;
+  background: var(--orange);
   color: #fff;
   padding: 0.75em 1.5em;
   border-radius: 8px;
@@ -83,7 +88,7 @@ body {
 }
 
 .cta:hover {
-  background: #0051d4;
+  background: #e06f00;
 }
 
 .info {
@@ -109,7 +114,7 @@ body {
 }
 
 footer {
-  background: #007aff;
+  background: var(--blue);
   color: #fff;
   text-align: center;
   padding: 1.5em;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <header class="hero">
     <h1>Recover and Protect with Confidence</h1>
     <p>Our experts are ready to help you bounce back from cyber incidents and safeguard your future.</p>
-    <a href="#contact" class="cta">Get Help Now</a>
+    <a href="#contact" class="cta">Get Support</a>
   </header>
 
   <section id="services" class="info">


### PR DESCRIPTION
## Summary
- add blue-orange gradient theme and adjust navigation colors
- reduce hero height and shorten CTA text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686db92d1f3883219772c0507099417e