### PR TITLE
Improve screen reader accessibility for icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -187,3 +187,19 @@ footer {
   max-width: 700px;
   text-align: center;
 }
+
+/*
+  Visually hide elements while keeping them
+  accessible to screen readers.
+*/
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <nav class="navbar">
     <div class="logo">We Hack Back</div>
     <button class="menu-toggle" aria-label="Toggle navigation">
-      <i class="fas fa-bars"></i>
+      <i class="fas fa-bars" aria-hidden="true"></i>
     </button>
     <ul class="nav-links">
       <li><a href="#services">Services</a></li>
@@ -27,17 +27,20 @@
 
   <section id="services" class="info">
     <div class="card">
-      <i class="fas fa-shield-alt fa-2x"></i>
+      <i class="fas fa-shield-alt fa-2x" aria-hidden="true"></i>
+      <span class="sr-only">Incident Response</span>
       <h3>Incident Response</h3>
       <p>Immediate assistance to contain breaches and guide you through recovery.</p>
     </div>
     <div class="card">
-      <i class="fas fa-user-secret fa-2x"></i>
+      <i class="fas fa-user-secret fa-2x" aria-hidden="true"></i>
+      <span class="sr-only">Forensics</span>
       <h3>Forensics</h3>
       <p>In-depth investigation and analysis to uncover what happened.</p>
     </div>
     <div class="card">
-      <i class="fas fa-lock fa-2x"></i>
+      <i class="fas fa-lock fa-2x" aria-hidden="true"></i>
+      <span class="sr-only">Prevention Planning</span>
       <h3>Prevention Planning</h3>
       <p>Strategies and training to help prevent future incidents.</p>
     </div>


### PR DESCRIPTION
## Summary
- hide icons from screen readers and provide hidden labels for those with meaning
- add a `.sr-only` helper class

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686de1d0ffb08321914843b7e575fc89