### PR TITLE
Tighten urgent guidance and homepage copy for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <main id="main-content">
     <div class="safety-banner" role="note">
       <div class="section-inner">
-        <p>If you're in immediate physical danger, contact local emergency services first. We'll help with digital safety and evidence.</p>
+        <p>In immediate danger? Call local emergency services. We handle digital safety and evidence.</p>
       </div>
     </div>
     <header class="hero">
@@ -39,8 +39,8 @@
         <div class="hero-inner">
           <div class="hero-main">
             <p class="eyebrow">Trauma-informed responders</p>
-            <h1>Free, confidential help after cybercrime.</h1>
-            <p class="lede">Calm, plain-language guidance to stop harm, collect evidence safely, and regain control without blame.</p>
+            <h1>Free, confidential cybercrime help.</h1>
+            <p class="lede">We stop harm, secure accounts, and preserve evidence.</p>
             <div class="hero-actions">
               <a href="#contact" class="cta">Request support</a>
               <a href="#emergency" class="secondary-cta">See urgent steps</a>
@@ -48,19 +48,19 @@
             <ul class="hero-promises">
               <li><i class="fas fa-shield-heart" aria-hidden="true"></i><span>Always free; we never ask for payment or passwords.</span></li>
               <li><i class="fas fa-stopwatch" aria-hidden="true"></i><span>4-hour response goal from a human responder.</span></li>
-              <li><i class="fas fa-hands-holding" aria-hidden="true"></i><span>Trauma-informed communication that keeps you in control.</span></li>
+              <li><i class="fas fa-hands-holding" aria-hidden="true"></i><span>You stay in control.</span></li>
             </ul>
           </div>
           <aside class="hero-support" aria-label="Response expectations">
             <div class="support-card">
               <p class="card-eyebrow">If you feel unsafe or overwhelmed</p>
-              <p class="card-copy">Pause, close suspicious tabs, and take screenshots. We’ll help you decide the safest next step.</p>
+              <p class="card-copy">Pause, close suspicious tabs, and take screenshots. We’ll guide next steps.</p>
               <div class="response-metric" role="presentation">
                 <p class="metric-label">Response goal</p>
                 <p class="metric-value">Within 4 hours</p>
               </div>
               <a class="cta ghost" href="mailto:help@wehackback.org">Email a responder</a>
-              <p class="card-note">You can share only what you’re comfortable sharing—we never blame victims.</p>
+              <p class="card-note">Share only what feels safe. No blame.</p>
             </div>
           </aside>
         </div>
@@ -72,19 +72,19 @@
       <div class="banner-content">
         <div>
           <p class="eyebrow">If something is happening right now</p>
-          <h2>Pause, capture evidence, and get a responder involved</h2>
-          <p>We guide you through containment and safe data collection so you can share what happened without risking further harm.</p>
+          <h2>Pause, capture evidence, and contact us</h2>
+          <p>We guide safe containment and evidence capture.</p>
           <ol class="steps ordered">
-            <li><span class="step-number" aria-hidden="true">1</span><span>Disconnect compromised devices from the internet if it is safe. Your safety comes first.</span></li>
-            <li><span class="step-number" aria-hidden="true">2</span><span>Take screenshots or photos of messages, pop-ups, or transactions before closing them.</span></li>
-            <li><span class="step-number" aria-hidden="true">3</span><span>Contact us with what you saw; include links or phone numbers if available.</span></li>
+            <li><span class="step-number" aria-hidden="true">1</span><span>If safe, disconnect affected devices.</span></li>
+            <li><span class="step-number" aria-hidden="true">2</span><span>Screenshot messages, pop-ups, or transactions before closing them.</span></li>
+            <li><span class="step-number" aria-hidden="true">3</span><span>Contact us with what you saw (links or phone numbers help).</span></li>
           </ol>
           <a class="cta" href="#contact">Tell us what happened</a>
         </div>
         <div class="banner-cta">
           <p class="hotline-label">Prefer to talk?</p>
           <a class="cta full-width" href="mailto:help@wehackback.org">Email a responder</a>
-          <p class="hotline-note">We never ask for payment or remote control of your device.</p>
+          <p class="hotline-note">We never ask for payment or remote control.</p>
         </div>
       </div>
     </div>
@@ -94,33 +94,33 @@
     <div class="section-inner">
       <div class="trust-header">
         <p class="eyebrow">WHAT WE DO</p>
-        <h2>Hands-on help from first alert to recovery</h2>
-        <p>Responders, investigators, and advocates work together to contain the incident, preserve evidence, and guide you to safer ground.</p>
+        <h2>Hands-on help from alert to recovery</h2>
+        <p>We contain incidents, preserve evidence, and guide recovery.</p>
       </div>
       <div class="card-grid">
         <div class="trust-card">
           <i class="fas fa-shield-alt fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Incident Response</span>
           <h3>Incident Response</h3>
-          <p>Immediate containment help, safe evidence collection, and step-by-step guidance to stop the damage.</p>
+          <p>Containment, safe evidence collection, and step-by-step guidance.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-user-secret fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Forensics</span>
           <h3>Forensics</h3>
-          <p>Investigation to understand what happened, what was taken, and what needs to be reported.</p>
+          <p>We identify what happened, what was taken, and what to report.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-lock fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Prevention Planning</span>
           <h3>Prevention Planning</h3>
-          <p>Actionable recovery plans, follow-up scans, and training to prevent repeat attacks.</p>
+          <p>Recovery plans, follow-up scans, and training to prevent repeat attacks.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-heart fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Victim Advocacy</span>
           <h3>Victim Advocacy</h3>
-          <p>Support contacting banks, platforms, and law enforcement with the evidence they need to act.</p>
+          <p>We help you contact banks, platforms, or law enforcement with evidence.</p>
         </div>
       </div>
     </div>
@@ -130,36 +130,36 @@
     <div class="section-inner">
       <div class="trust-header">
         <p class="eyebrow">How we work</p>
-        <h2>Built on security principles you can verify</h2>
-        <p>Every case follows documented playbooks, transparent communication, and industry standards designed to keep your data safe.</p>
+        <h2>Clear, verified security practices</h2>
+        <p>We follow documented playbooks and standards to protect your data.</p>
       </div>
       <div class="card-grid">
         <div class="trust-card">
           <i class="fas fa-user-check fa-2x" aria-hidden="true"></i>
           <h3>Vetted responders</h3>
-          <p>Incident handlers with enterprise security backgrounds and public-interest experience, backed by NDAs for sensitive work.</p>
+          <p>Experienced incident handlers with public-interest training and NDAs.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-clipboard-list fa-2x" aria-hidden="true"></i>
           <h3>Documented process</h3>
-          <p>Clear runbooks for triage, containment, and recovery mapped to NIST CSF so you always know the next step.</p>
+          <p>Runbooks for triage, containment, and recovery mapped to NIST CSF.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-lock fa-2x" aria-hidden="true"></i>
           <h3>Data handling discipline</h3>
-          <p>Scoped access, encrypted handoffs, and minimal data retention to protect evidence and privacy.</p>
+          <p>Scoped access, encrypted handoffs, and minimal data retention.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-hand-holding-heart fa-2x" aria-hidden="true"></i>
           <h3>Victim-centered approach</h3>
-          <p>Communication that avoids blame, prioritizes your consent, and keeps you in control of decisions.</p>
+          <p>No blame, clear consent, and you control decisions.</p>
         </div>
       </div>
       <ul class="checklist">
-        <li><i class="fas fa-check" aria-hidden="true"></i><span>4-hour response goal for new cases and a dedicated point of contact throughout the incident.</span></li>
-        <li><i class="fas fa-check" aria-hidden="true"></i><span>Post-incident hardening plan with prioritized fixes and training materials tailored to your risk.</span></li>
-        <li><i class="fas fa-check" aria-hidden="true"></i><span>Partnership-friendly: ready to collaborate with your legal counsel, insurer, or MSP.</span></li>
-        <li><i class="fas fa-check" aria-hidden="true"></i><span>Respectful of your pace: we align with what feels safe for you and your household or team.</span></li>
+        <li><i class="fas fa-check" aria-hidden="true"></i><span>4-hour response goal and a single point of contact.</span></li>
+        <li><i class="fas fa-check" aria-hidden="true"></i><span>Post-incident hardening plan with prioritized fixes.</span></li>
+        <li><i class="fas fa-check" aria-hidden="true"></i><span>We can coordinate with legal counsel, insurers, or MSPs.</span></li>
+        <li><i class="fas fa-check" aria-hidden="true"></i><span>We move at your pace and what feels safe.</span></li>
       </ul>
     </div>
   </section>
@@ -169,24 +169,24 @@
       <div class="trust-header">
         <p class="eyebrow">What to expect</p>
         <h2>What happens after you reach out</h2>
-        <p>We stay transparent about timelines and actions so you know what is happening and why.</p>
+        <p>Clear timelines and actions so you know what’s next.</p>
       </div>
       <div class="card-grid">
         <div class="trust-card">
           <h3>You contact us</h3>
-          <p>Share the safest way to reach you and whatever details you have — pseudonyms are welcome.</p>
+          <p>Share the safest way to reach you and what you know.</p>
         </div>
         <div class="trust-card">
           <h3>We respond in about 4 hours</h3>
-          <p>A responder confirms receipt, shares initial containment steps, and sets expectations.</p>
+          <p>A responder confirms receipt and shares initial steps.</p>
         </div>
         <div class="trust-card">
           <h3>Contain &amp; collect evidence</h3>
-          <p>We help you reduce exposure and capture proof the right way for platforms or authorities.</p>
+          <p>We reduce exposure and capture proof for platforms or authorities.</p>
         </div>
         <div class="trust-card">
           <h3>Support reporting &amp; recovery</h3>
-          <p>Guidance to notify banks, platforms, or law enforcement, plus follow-up to harden accounts.</p>
+          <p>We guide reporting and follow-up to harden accounts.</p>
         </div>
       </div>
     </div>
@@ -196,8 +196,8 @@
     <div class="section-inner">
       <div class="trust-header">
         <p class="eyebrow">Who we help</p>
-        <h2>You deserve real support, not judgment</h2>
-        <p>Different victims, same promise: calm guidance, clear steps, and evidence handled with care.</p>
+        <h2>Support without judgment</h2>
+        <p>Calm guidance, clear steps, careful evidence handling.</p>
       </div>
       <div class="card-grid">
         <div class="trust-card">
@@ -205,21 +205,21 @@
           <span class="sr-only">Small businesses</span>
           <h3>Small businesses</h3>
           <p class="role">Ransomware, invoice fraud, business email compromise</p>
-          <p>We triage attacks, coordinate with vendors, and prepare the evidence insurers and lawyers need.</p>
+          <p>We triage attacks, coordinate with vendors, and prepare evidence.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-users fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Individuals and families</span>
           <h3>Individuals &amp; families</h3>
           <p class="role">Account takeover, sextortion, harassment</p>
-          <p>We help secure accounts, preserve proof for investigators, and reduce exposure on devices and platforms.</p>
+          <p>We secure accounts, preserve proof, and reduce exposure.</p>
         </div>
         <div class="trust-card">
           <i class="fas fa-hands-helping fa-2x" aria-hidden="true"></i>
           <span class="sr-only">Nonprofits and community organizations</span>
           <h3>Nonprofits &amp; community orgs</h3>
           <p class="role">Doxing, credential theft, targeted phishing</p>
-          <p>We design quick mitigations that keep critical services running and protect staff and volunteers.</p>
+          <p>We deliver quick mitigations that protect staff and services.</p>
         </div>
       </div>
     </div>
@@ -229,15 +229,15 @@
     <div class="section-inner narrow">
       <div class="contact-wrapper">
         <p class="eyebrow">Reach our responders</p>
-        <h2>Ready to get started?</h2>
+        <h2>Request support</h2>
         <div class="contact-card">
-          <p class="contact-intro">Share what happened and how to contact you. We aim to respond within 4 hours.</p>
-          <p class="contact-alt">Prefer to use your own email? Send details to <a href="mailto:help@wehackback.org">help@wehackback.org</a>.</p>
+          <p class="contact-intro">Share what happened and how to contact you. Response goal: within 4 hours.</p>
+          <p class="contact-alt">Prefer email? Send details to <a href="mailto:help@wehackback.org">help@wehackback.org</a>.</p>
           <div class="contact-trust" role="note" aria-label="Trust information">
             <p><i class="fas fa-ban" aria-hidden="true"></i>No payment, passwords, or remote-control requests.</p>
-            <p><i class="fas fa-lock" aria-hidden="true"></i>Your info is used only to respond, unless law requires otherwise.</p>
+            <p><i class="fas fa-lock" aria-hidden="true"></i>Your info is used only to respond, unless law requires more.</p>
           </div>
-          <p class="reassurance">You are not to blame for what happened, and it’s okay if you don’t remember every detail.</p>
+          <p class="reassurance">You are not to blame. Share only what you remember.</p>
           <form class="contact-form" action="mailto:help@wehackback.org" method="POST" enctype="text/plain">
             <fieldset class="form-step" data-step="1">
               <legend class="sr-only">How can we reach you</legend>
@@ -279,7 +279,7 @@
               <div class="field-group">
                 <label for="message">What happened?</label>
                 <textarea id="message" name="message" placeholder="Example: Received threats demanding money after sending photos; Instagram account locked; got links from +44 number." rows="5" required></textarea>
-                <p class="helper-text">Plain language is enough—you don’t need perfect technical terms.</p>
+                <p class="helper-text">Plain language is enough.</p>
               </div>
             </fieldset>
 
@@ -307,13 +307,13 @@
       <div class="footer-content">
         <div>
           <p class="logo">We Hack Back</p>
-          <p class="tagline">We Hack Back — we don’t break the law; we help you take your power back online.</p>
-          <p>Free incident response and security help for victims of cybercrime.</p>
+          <p class="tagline">We Hack Back — we help you take your power back online.</p>
+          <p>Free incident response and security help for cybercrime victims.</p>
         </div>
         <div>
           <p class="footer-heading">Need help?</p>
           <p>Email <a href="mailto:help@wehackback.org">help@wehackback.org</a></p>
-          <p class="footer-note">We will never pressure you to pay or share passwords.</p>
+          <p class="footer-note">We will never ask for payment or passwords.</p>
         </div>
       </div>
       <p class="copyright">&copy; 2024 We Hack Back. All rights reserved.</p>


### PR DESCRIPTION
### Motivation
- Improve scan-ability and reduce wordiness in the homepage so people in crisis can find next steps quickly. 
- Make immediate-danger guidance and response expectations more direct while preserving layout and structure. 
- Remove ambiguous phrasing and unnecessary qualifiers to emphasize safety, consent, and actionable steps.

### Description
- Updated copy in `index.html` across the safety banner, hero lede/promises, emergency steps, services, trust, expectations, victims, contact card, and footer to be shorter and more direct. 
- Simplified emergency instructions (e.g. "If safe, disconnect affected devices"), tightened responder/consent language, and shortened helper notes like `Plain language is enough`. 
- Kept existing markup and structure intact (no functional changes), with only text edits to make messaging clearer. 
- All edits are contained to the `index.html` file.

### Testing
- Launched a local static server with `python -m http.server 8000` which served the site successfully. 
- Ran a Playwright script to load `http://127.0.0.1:8000/` and capture a full-page screenshot saved as `artifacts/we-hack-back-home.png`, which completed successfully. 
- No unit or integration tests were run because the change is static content only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69698d672d948321af4a32e8eb96a5af)